### PR TITLE
テンプレートパス指定ミスでビルド失敗するのを修正

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -68,7 +68,7 @@ const config: Configuration = {
   },
   plugins: [
     new HtmlWebPackPlugin({
-      template: '/src/popup.html',
+      template: './src/popup.html',
     }),
     new CopyPlugin({
       patterns: [


### PR DESCRIPTION
Windows環境で、`yarn build`時にエラーが出て失敗するのを修正しました（Windows環境以外は未検証です。すいません。）。
webpackのテンプレート指定を修正しました。

### 修正前

```
> yarn build
yarn run v1.22.19
$ webpack
assets by status 2.45 MiB [emitted]
  asset popup.js 2.45 MiB [emitted] (name: popup)
  asset index.html 3.44 KiB [emitted]
  asset background.js 1.42 KiB [emitted] (name: background)
assets by status 3.11 KiB [compared for emit]
  asset src/assets/earth-48px.png 1.54 KiB [compared for emit] [from: src/assets/earth-48px.png] [copied]
  asset src/assets/earth-32px.png 1.04 KiB [compared for emit] [from: src/assets/earth-32px.png] [copied]
  asset manifest.json 538 bytes [compared for emit] [from: manifest.json] [copied]
modules by path ./node_modules/ 974 KiB
  modules by path ./node_modules/scheduler/ 26.3 KiB
    modules by path ./node_modules/scheduler/*.js 412 bytes 2 modules
    modules by path ./node_modules/scheduler/cjs/*.js 25.9 KiB 2 modules
  modules by path ./node_modules/react/ 70.6 KiB
    ./node_modules/react/index.js 190 bytes [built] [code generated]
    ./node_modules/react/cjs/react.development.js 70.5 KiB [built] [code generated]
  modules by path ./node_modules/react-dom/ 875 KiB
    ./node_modules/react-dom/index.js 1.33 KiB [built] [code generated]
    ./node_modules/react-dom/cjs/react-dom.development.js 874 KiB [built] [code generated]
  ./node_modules/object-assign/index.js 2.06 KiB [built] [code generated]
modules by path ./src/ 2.18 KiB
  ./src/App.tsx 581 bytes [built] [code generated]
  ./src/background/background.ts 225 bytes [built] [code generated]
  ./src/components/popup/PopUp.tsx 1.39 KiB [built] [code generated]

ERROR in   Error: Child compilation failed:
  Module not found: Error: Can't resolve 'C:\src\popup.html' in 'C:\Users\acous\Desktop\chrome-extension-react-ts-boiler'
  ModuleNotFoundError: Module not found: Error: Can't resolve 'C:\src\popup.html' in 'C:\Users\acous\Desktop\chrome-extension-react-ts-bo  iler'
      at C:\Users\acous\Desktop\chrome-extension-react-ts-boiler\node_modules\webpack\lib\Compilation.js:2011:28
      at C:\Users\acous\Desktop\chrome-extension-react-ts-boiler\node_modules\webpack\lib\NormalModuleFactory.js:795:13
      at eval (eval at create (C:\Users\acous\Desktop\chrome-extension-react-ts-boiler\node_modules\tapable\lib\HookCodeFactory.js:33:10)  , <anonymous>:10:1)
      at C:\Users\acous\Desktop\chrome-extension-react-ts-boiler\node_modules\webpack\lib\NormalModuleFactory.js:275:22
      at eval (eval at create (C:\Users\acous\Desktop\chrome-extension-react-ts-boiler\node_modules\tapable\lib\HookCodeFactory.js:33:10)  , <anonymous>:9:1)
      at C:\Users\acous\Desktop\chrome-extension-react-ts-boiler\node_modules\webpack\lib\NormalModuleFactory.js:431:22
      at C:\Users\acous\Desktop\chrome-extension-react-ts-boiler\node_modules\webpack\lib\NormalModuleFactory.js:124:11
      at C:\Users\acous\Desktop\chrome-extension-react-ts-boiler\node_modules\webpack\lib\NormalModuleFactory.js:667:25
      at C:\Users\acous\Desktop\chrome-extension-react-ts-boiler\node_modules\webpack\lib\NormalModuleFactory.js:852:8
      at C:\Users\acous\Desktop\chrome-extension-react-ts-boiler\node_modules\webpack\lib\NormalModuleFactory.js:972:5
```

### 修正後

```
> yarn build
yarn run v1.22.19
$ webpack
assets by path *.js 2.45 MiB
  asset popup.js 2.45 MiB [compared for emit] (name: popup)
  asset background.js 1.42 KiB [compared for emit] (name: background)
assets by path src/assets/*.png 2.58 KiB
  asset src/assets/earth-48px.png 1.54 KiB [compared for emit] [from: src/assets/earth-48px.png] [copied]
  asset src/assets/earth-32px.png 1.04 KiB [compared for emit] [from: src/assets/earth-32px.png] [copied]
asset manifest.json 538 bytes [compared for emit] [from: manifest.json] [copied]
asset index.html 220 bytes [emitted]
modules by path ./node_modules/ 974 KiB
  modules by path ./node_modules/scheduler/ 26.3 KiB
    modules by path ./node_modules/scheduler/*.js 412 bytes 2 modules
    modules by path ./node_modules/scheduler/cjs/*.js 25.9 KiB 2 modules
  modules by path ./node_modules/react/ 70.6 KiB
    ./node_modules/react/index.js 190 bytes [built] [code generated]
    ./node_modules/react/cjs/react.development.js 70.5 KiB [built] [code generated]
  modules by path ./node_modules/react-dom/ 875 KiB
    ./node_modules/react-dom/index.js 1.33 KiB [built] [code generated]
    ./node_modules/react-dom/cjs/react-dom.development.js 874 KiB [built] [code generated]
  ./node_modules/object-assign/index.js 2.06 KiB [built] [code generated]
modules by path ./src/ 2.18 KiB
  ./src/App.tsx 581 bytes [built] [code generated]
  ./src/background/background.ts 225 bytes [built] [code generated]
  ./src/components/popup/PopUp.tsx 1.39 KiB [built] [code generated]
webpack 5.62.1 compiled successfully in 12438 ms
Done in 27.15s.
```